### PR TITLE
Fix #60: Exclude ehcache Spring WS security dependency

### DIFF
--- a/powerauth-admin/pom.xml
+++ b/powerauth-admin/pom.xml
@@ -31,6 +31,16 @@
 		<dependency>
 			<groupId>org.springframework.ws</groupId>
 			<artifactId>spring-ws-security</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>ehcache</artifactId>
+					<groupId>net.sf.ehcache</groupId>
+				</exclusion>
+				<exclusion>
+					<artifactId>geronimo-javamail_1.4_mail</artifactId>
+					<groupId>org.apache.geronimo.javamail</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Exclude geronimo-javamail due to issues found in OWASP report