### PR TITLE
Fix #73: Improve display of signature data for ECIES requests

### DIFF
--- a/powerauth-admin/src/main/webapp/WEB-INF/jsp/activationDetail.jsp
+++ b/powerauth-admin/src/main/webapp/WEB-INF/jsp/activationDetail.jsp
@@ -240,7 +240,7 @@
                                                 Signed Data
                                                 <c:choose>
                                                     <c:when test="${not empty item.signatureData}">
-                                                        <span class="glyphicon glyphicon-zoom-in" data-toggle="tooltip" data-html="true" data-placement="top" title="<table><tr><td>Request&nbsp;method:&nbsp;&nbsp;&nbsp;</td><td><c:out value="${item.signatureData.requestMethod}"/></td></tr><tr><td>Request&nbsp;URI:</td><td><c:out value="${item.signatureData.requestURIIdentifier}"/></td></tr><tr><td>Request&nbsp;body:</td><td><c:out value="${item.signatureData.requestBody}"/></span></td></tr></table>"></span>
+                                                        <span class="glyphicon glyphicon-zoom-in" data-toggle="tooltip" data-html="true" data-placement="top" title="<table><tr><td>Request&nbsp;method:&nbsp;&nbsp;&nbsp;</td><td><c:out value="${item.signatureData.requestMethod}"/></td></tr><tr><td>Request&nbsp;URI:</td><td><c:out value="${item.signatureData.requestURIIdentifier}"/></td></tr><tr><td>Request&nbsp;body:</td><td><span class='word-break'><c:out value="${item.signatureData.requestBody}"/></span></td></tr></table>"></span>
                                                     </c:when>
                                                     <c:otherwise>
                                                         <span class="glyphicon glyphicon-zoom-in" data-toggle="tooltip" data-html="true" data-placement="top" title="Unrecognized signature data"></span>

--- a/powerauth-admin/src/main/webapp/resources/css/base.css
+++ b/powerauth-admin/src/main/webapp/resources/css/base.css
@@ -102,3 +102,7 @@ pre.code, pre.code code {
 .tooltip-inner td {
     vertical-align: top;
 }
+
+.tooltip-inner td .word-break {
+    word-break: break-all;
+}


### PR DESCRIPTION
ECIES data after CSS fix:

![image](https://user-images.githubusercontent.com/26658588/47529995-abe84a00-d8a9-11e8-80f9-85c146d60cbd.png)
