### PR TITLE
Exclude old Bouncy Castle library versions

### DIFF
--- a/powerauth-admin/pom.xml
+++ b/powerauth-admin/pom.xml
@@ -35,6 +35,10 @@
                     <artifactId>geronimo-javamail_1.4_mail</artifactId>
                     <groupId>org.apache.geronimo.javamail</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                    <groupId>org.bouncycastle</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -55,6 +59,12 @@
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-server-jndi</artifactId>
             <version>1.5.5</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>bcprov-jdk15</artifactId>
+                    <groupId>bouncycastle</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- PowerAuth Dependencies -->


### PR DESCRIPTION
PowerAuth admin does not start on server, so I will exclude old versions of Bouncy Castle libraries which solves the issue.

The error was:
```Unable to complete the scan for annotations for web application [/powerauth-admin] due to a StackOverflowError. Possible root causes include a too low setting for -Xss and illegal cyclic inheritance dependencies. The class hierarchy being processed was [org.bouncycastle.asn1.ASN1EncodableVector->org.bouncycastle.asn1.DEREncodableVector->org.bouncycastle.asn1.ASN1EncodableVector]```