### PR TITLE
Simplify externalization of application.properties

### DIFF
--- a/docs/Deploying-PowerAuth-Admin.md
+++ b/docs/Deploying-PowerAuth-Admin.md
@@ -55,7 +55,7 @@ To deploy PowerAuth Admin to Apache Tomcat, simply copy the WAR file in your `we
 
 *__Important note: Since PowerAuth Admin is a very simple application with direct access to the PowerAuth Server SOAP services, it must not be under any circumstances published publicly and must be constrained to the in-house closed infrastructure.__*
 
-## Deploying PowerAuth Admin outside the container
+## Deploying PowerAuth Admin Outside the Container
 
 You can also execute WAR file directly using the following command:
 
@@ -66,3 +66,7 @@ java -jar powerauth-admin.war
 _Note: You can overwrite the port using `-Dserver.port=8090` parameter to avoid port conflicts._
 
 *__Important note: Since PowerAuth Admin is a very simple application with direct access to the PowerAuth Server SOAP services, it must not be under any circumstances published publicly and must be constrained to the in-house closed infrastructure.__*
+
+## Deploying PowerAuth Admin On JBoss / Wildfly
+
+Follow the extra instructions in chapter [Deploying PowerAuth Admin on JBoss / Wildfly](./Deploying-Wildfly.md).

--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -86,3 +86,5 @@ powerauth.service.url=http://[host]:[port]/powerauth-java-server/soap
 # Application Service Configuration
 powerauth.admin.service.applicationEnvironment=TEST
 ```
+
+PowerAuth Admin Spring application uses the `ext` Spring profile which activates overriding of default properties by `application-ext.properties`.

--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -2,7 +2,7 @@
 
 ## JBoss Deployment Descriptor 
 
-PowerAuth admin contains the following configuration in `jboss-deployment-structure.xml` file for JBoss:
+PowerAuth Admin contains the following configuration in `jboss-deployment-structure.xml` file for JBoss:
 
 ```
 <?xml version="1.0"?>

--- a/docs/Deploying-Wildfly.md
+++ b/docs/Deploying-Wildfly.md
@@ -86,13 +86,3 @@ powerauth.service.url=http://[host]:[port]/powerauth-java-server/soap
 # Application Service Configuration
 powerauth.admin.service.applicationEnvironment=TEST
 ```
-
-## Enabling External Application Configuration 
-
-In order to enable external configuration for the `application.properties` configuration file, set the following environment property before starting JBoss:
-
-```
-SPRING_CONFIG_LOCATION=classpath:/application.properties,classpath:/application-ext.properties
-```
-
-The properties configured in the `application-ext.properties` file take precedence over default configuration. Changes in this file are applied after application restart.

--- a/powerauth-admin/src/main/java/io/getlime/security/app/admin/PowerAuthAdminApplication.java
+++ b/powerauth-admin/src/main/java/io/getlime/security/app/admin/PowerAuthAdminApplication.java
@@ -18,7 +18,6 @@ package io.getlime.security.app.admin;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.PropertySource;
 
 /**
  * Spring Boot application main class

--- a/powerauth-admin/src/main/java/io/getlime/security/app/admin/configuration/ApplicationConfiguration.java
+++ b/powerauth-admin/src/main/java/io/getlime/security/app/admin/configuration/ApplicationConfiguration.java
@@ -17,6 +17,7 @@
 package io.getlime.security.app.admin.configuration;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -26,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Petr Dvorak, petr@wultra.com
  */
 @Configuration
+@ConfigurationProperties("ext")
 @ComponentScan(basePackages = {"io.getlime.security.powerauth"})
 public class ApplicationConfiguration {
 

--- a/powerauth-admin/src/main/resources/application.properties
+++ b/powerauth-admin/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+# Allow externalization of properties using application-ext.properties
+spring.profiles.active=ext
+
 # Spring MVC configuration
 spring.mvc.view.prefix=/WEB-INF/jsp/
 spring.mvc.view.suffix=.jsp


### PR DESCRIPTION
Configuration using `application-ext.properties` is now automatically enabled using Spring profile as suggested by one of our integration partners.

I tested it with Wildfly (using configuration module which adds `application-ext.properties` on classpath) and on Tomcat (using regular `context.xml` parameters which ignores `application-ext.properties` completely), configuration and parameter overriding with inheritance works fine.