### PR TITLE
Fix #133: The HTML tooltip of signed data in last signatures is not shown

### DIFF
--- a/powerauth-admin/src/main/webapp/WEB-INF/jsp/activationDetail.jsp
+++ b/powerauth-admin/src/main/webapp/WEB-INF/jsp/activationDetail.jsp
@@ -422,6 +422,14 @@
 
 <script>
     $(document).ready(function (event) {
+        // Disable HTML sanitizer for signature data tooltip
+        const whiteList = $.fn.tooltip.Constructor.DEFAULTS.whiteList;
+        whiteList.table = [];
+        whiteList.tr = [];
+        whiteList.td = [];
+        whiteList.tbody = [];
+        whiteList.thead = [];
+        whiteList.span = ['class'];
         // Choose tab by location hash
         if (!window.location.hash) {
             $('a[href="#signatures"]').tab('show');


### PR DESCRIPTION
The issue was fixed by adding a whitelist for table tags and span.