### PR TITLE
Additional activation OTP

### DIFF
--- a/powerauth-admin/src/main/webapp/WEB-INF/jsp/activationDetail.jsp
+++ b/powerauth-admin/src/main/webapp/WEB-INF/jsp/activationDetail.jsp
@@ -411,7 +411,15 @@
                                         <c:choose>
                                             <c:when test="${not empty item.blockedReason}">
                                                 <td>
-                                                    Blocked Reason<br>
+                                                    <c:choose>
+                                                        <c:when test="${item.activationStatus == 'BLOCKED'}">
+                                                            Blocked Reason
+                                                        </c:when>
+                                                        <c:otherwise>
+                                                            Event Reason
+                                                        </c:otherwise>
+                                                    </c:choose>
+                                                    <br>
                                                     <span class="orange code">
                                                         <c:out value="${item.blockedReason}"/>
                                                     </span>


### PR DESCRIPTION
This small change is about to show a correct title for activation status history. The status history table now contains also events generated when wrong activation OTP is provided during the activation commit. For this case, we show "Event Reason" instead of "Blocked Reason" title.

![event-reason](https://user-images.githubusercontent.com/1719814/77557931-9fab5680-6eba-11ea-8b27-9a607d997fb1.png)
